### PR TITLE
Add SVt_RV case for older Perl(< 5.11)

### DIFF
--- a/lib/Linux/Socket/Accept4.xs
+++ b/lib/Linux/Socket/Accept4.xs
@@ -49,6 +49,9 @@ PPCODE:
                 nstio = sv_2io(ST(0));
                 break;
             case SVt_IV:
+#if PERL_VERSION < 11
+            case SVt_RV:
+#endif
                 if (SvROK(ST(0))) {
                     nstio = sv_2io(ST(0));
                     break;


### PR DESCRIPTION
On newer Perl, SVt_RV equals to SVt_IV. While on older Perl,
SVt_RV does not equal to SVt_IV. So default case is executed
if first argument is reference on older Perl.
